### PR TITLE
Add extended version for create user

### DIFF
--- a/data/org.freedesktop.Accounts.xml
+++ b/data/org.freedesktop.Accounts.xml
@@ -91,6 +91,55 @@
       </doc:doc>
     </method>
 
+    <method name="CreateUserEx">
+      <arg name="name" direction="in" type="s">
+        <doc:doc><doc:summary>The username for the new user</doc:summary></doc:doc>
+      </arg>
+      <arg name="fullname" direction="in" type="s">
+        <doc:doc><doc:summary>The real name for the new user</doc:summary></doc:doc>
+      </arg>
+      <arg name="user" direction="out" type="o">
+        <doc:doc><doc:summary>Object path of the new user</doc:summary></doc:doc>
+      </arg>
+      <arg name="accountType" direction="in" type="i">
+        <doc:doc>
+          <doc:summary>The account type, encoded as an integer</doc:summary>
+        </doc:doc>
+      </arg>
+      <arg name="uid" direction="in" type="u">
+        <doc:doc>
+          <doc:summary>The user id, encoded as an integer</doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Creates a new user account.
+          </doc:para>
+          <doc:para>
+          The accountType argument can take the following values:
+          </doc:para>
+            <doc:list>
+              <doc:item>
+                <doc:term>0</doc:term>
+                <doc:definition>Standard user</doc:definition>
+              </doc:item>
+              <doc:item>
+                <doc:term>1</doc:term>
+                <doc:definition>Administrator</doc:definition>
+              </doc:item>
+            </doc:list>
+        </doc:description>
+        <doc:permission>
+          The caller needs the org.freedesktop.accounts.user-administration PolicyKit authorization.
+        </doc:permission>
+        <doc:errors>
+          <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+          <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+        </doc:errors>
+      </doc:doc>
+    </method>
+
     <method name="CacheUser">
       <arg name="name" direction="in" type="s">
         <doc:doc><doc:summary>The username for the user</doc:summary></doc:doc>

--- a/src/libaccountsservice/act-user-manager.c
+++ b/src/libaccountsservice/act-user-manager.c
@@ -668,6 +668,7 @@ act_user_manager_create_user (ActUserManager      *manager,
                               const char          *username,
                               const char          *fullname,
                               ActUserAccountType   accounttype,
+                              uid_t                uid,
                               GError             **error)
 {
         GError *local_error = NULL;
@@ -681,13 +682,14 @@ act_user_manager_create_user (ActUserManager      *manager,
         g_assert (manager->priv->accounts_proxy != NULL);
 
         local_error = NULL;
-        res = act_user_manager_glue_call_create_user_sync (manager->priv->accounts_proxy,
-                                                           username,
-                                                           fullname,
-                                                           accounttype,
-                                                           &path,
-                                                           NULL,
-                                                           &local_error);
+        res = act_user_manager_glue_call_create_user_ex_sync (manager->priv->accounts_proxy,
+                                                              username,
+                                                              fullname,
+                                                              accounttype,
+                                                              uid,
+                                                              &path,
+                                                              NULL,
+                                                              &local_error);
         if (! res) {
                 g_propagate_error (error, local_error);
                 return NULL;

--- a/src/libaccountsservice/act-user-manager.h
+++ b/src/libaccountsservice/act-user-manager.h
@@ -87,6 +87,7 @@ ActUser *           act_user_manager_create_user           (ActUserManager     *
                                                             const char         *username,
                                                             const char         *fullname,
                                                             ActUserAccountType  accounttype,
+                                                            uid_t               uid,
                                                             GError             **error);
 
 ActUser *           act_user_manager_cache_user            (ActUserManager     *manager,


### PR DESCRIPTION
The create user function is missing at least 1 important option: UID.
In some cases I want to provide the UID to force useradd to use this UID and not the automatically created one.
To not break the original create user function I've added a new one.
